### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
-# archived
-
-prettier made some changes that breaks plugins entirely
-
-___
-
-
 prettier mirror
 ===============
-
-This is a fork of the (now archived) https://github.com/pre-commit/mirrors-prettier with the only difference 
-being that it only references release versions of prettier, not e.g. alpha/beta versions.
 
 Mirror of prettier package for pre-commit.
 
@@ -31,19 +21,6 @@ Add this to your `.pre-commit-config.yaml`:
 
 *note*: only prettier versions >= 2.1.0 are supported
 
-When using plugins with `prettier` you'll need to declare them under
-`additional_dependencies`. For example:
-
-```yaml
--   repo: https://github.com/rbubley/mirrors-prettier
-    rev: ''  # Use the sha / tag you want to point at
-    hooks:
-    -   id: prettier
-        additional_dependencies:
-        -   prettier@2.1.2
-        -   '@prettier/plugin-xml@0.12.0'
-```
-
 By default, all files are passed to `prettier`, if you want to limit the
 file list, adjust `types` / `types_or` / `files`:
 
@@ -51,3 +28,9 @@ file list, adjust `types` / `types_or` / `files`:
     -   id: prettier
         types_or: [css, javascript]
 ```
+
+
+### History
+
+This is a fork of the (now archived) https://github.com/pre-commit/mirrors-prettier with the only difference 
+being that it only references release versions of prettier, not e.g. alpha/beta versions.


### PR DESCRIPTION
Hello! Since this seems like a stable mirror that will stick around for a long whie, I think we can clean up some of the README mentions that might worry future adopters.

I also removed the part about how to include `prettier` plugins, since that doesn't seem to work (from my testing).